### PR TITLE
articleのモデルとvalidationの実装

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -1,0 +1,2 @@
+class Article < ApplicationRecord
+end

--- a/db/migrate/20221026033302_create_articles.rb
+++ b/db/migrate/20221026033302_create_articles.rb
@@ -1,0 +1,8 @@
+class CreateArticles < ActiveRecord::Migration[6.0]
+  def change
+    create_table :articles do |t|
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20221026040957_add_title_to_article.rb
+++ b/db/migrate/20221026040957_add_title_to_article.rb
@@ -1,0 +1,6 @@
+class AddTitleToArticle < ActiveRecord::Migration[6.0]
+  def change
+    add_column :articles, :title, :string
+    add_column :articles, :content, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,17 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_10_24_000843) do
+ActiveRecord::Schema.define(version: 2022_10_26_040957) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "articles", force: :cascade do |t|
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.string "title"
+    t.text "content"
+  end
 
   create_table "sample_articles", force: :cascade do |t|
     t.string "title"


### PR DESCRIPTION
##  概要
・bundle exec rails g  model articleによりarticleのモデルとdb/~create_articles.rbが作成
・models/article.rbにvalidation:{カラム名}, {ルール名}: {ルールの内容}を書くことによりカラムや入力情報に制限をかけることができる
・bundle exec rails db:migrateによりデータベースにmigrationファイル(追加のカラムを作成後)を更新