### PR TITLE
i18nを導入してアプリを日本語化

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,9 @@ gem 'jbuilder', '~> 2.7'
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.4.2', require: false
 
+# rails6系なら以下を記述(railsのバージョンを記述)
+gem 'rails-i18n', '~> 6.0'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -129,6 +129,9 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.4.3)
       loofah (~> 2.3)
+    rails-i18n (6.0.0)
+      i18n (>= 0.7, < 2)
+      railties (>= 6.0.0, < 7)
     railties (6.0.6)
       actionpack (= 6.0.6)
       activesupport (= 6.0.6)
@@ -199,6 +202,7 @@ DEPENDENCIES
   pry-rails
   puma (~> 4.1)
   rails (~> 6.0.3, >= 6.0.3.7)
+  rails-i18n (~> 6.0)
   sass-rails (>= 6)
   spring
   spring-watcher-listen (~> 2.0.0)

--- a/app/views/articles/edit.html.erb
+++ b/app/views/articles/edit.html.erb
@@ -2,5 +2,5 @@
 
 <%= render 'form', article: @article %>
 
-<%= link_to 'Show', @article %> |
-<%= link_to 'Back', articles_path %>
+<%= link_to '一覧', @article %> |
+<%= link_to 'TOP', articles_path %>

--- a/app/views/articles/index.html.erb
+++ b/app/views/articles/index.html.erb
@@ -1,12 +1,13 @@
 <p id="notice"><%= notice %></p>
+<%= render 'layouts/menu' %>
 
-<h1>Articles</h1>
+<h1>記事</h1>
 
 <table>
   <thead>
     <tr>
-      <th>Title</th>
-      <th>Content</th>
+      <th>タイトル</th>
+      <th>内容</th>
       <th colspan="3"></th>
     </tr>
   </thead>
@@ -16,9 +17,9 @@
       <tr>
         <td><%= article.title %></td>
         <td><%= article.content %></td>
-        <td><%= link_to 'Show', article %></td>
-        <td><%= link_to 'Edit', edit_article_path(article) %></td>
-        <td><%= link_to 'Destroy', article, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+        <td><%= link_to '詳細', article %></td>
+        <td><%= link_to '編集', edit_article_path(article) %></td>
+        <td><%= link_to '削除', article, method: :delete, data: { confirm: 'Are you sure?' } %></td>
       </tr>
     <% end %>
   </tbody>
@@ -26,4 +27,4 @@
 
 <br>
 
-<%= link_to 'New Article', new_article_path %>
+<%= link_to '新しく記事作成', new_article_path %>

--- a/app/views/articles/new.html.erb
+++ b/app/views/articles/new.html.erb
@@ -1,5 +1,3 @@
-<h1>New Article</h1>
-
 <%= render 'form', article: @article %>
 
-<%= link_to 'Back', articles_path %>
+<%= link_to '一覧', articles_path %>

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -1,14 +1,14 @@
 <p id="notice"><%= notice %></p>
 
 <p>
-  <strong>Title:</strong>
+  <strong><%= t '.title' %></strong>
   <%= @article.title %>
 </p>
 
 <p>
-  <strong>Content:</strong>
+  <strong><%= t '.content' %></strong>
   <%= @article.content %>
 </p>
 
-<%= link_to 'Edit', edit_article_path(@article) %> |
-<%= link_to 'Back', articles_path %>
+<%= link_to '編集', edit_article_path(@article) %> |
+<%= link_to '一覧', articles_path %>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,21 @@
+ja:
+    # モデルは全て activerecord 以下に記述する。
+  activerecord:
+    models:
+      article:
+        attributes:
+          title:
+          content:
+  # ビューはビューを格納しているフォルダ名を起点にし、ビュー名毎に記述する。
+  # 対応するビューの中ではツリーを省略できる。<%= t '.title' %>
+    models:
+      article: "記事"
+    attributes:
+      article:
+        title: "タイトル"
+        content: "内容"
+# lazy lookup 「Controllerやviewファイルのディレクトリの階層」を翻訳ファイルに設定する事で、Controllerやviewファイルの内部で参照するキーを短縮してアクセスする事が出来る仕組み
+  articles:
+    show:
+      title: "一覧"
+      content: "内容"


### PR DESCRIPTION
## 概要
・config/application.rbに日本語化コードを追加
・翻訳ファイルを設定した言語化ファイルconfig/locales/ja.ymlを作成
・各々のviewsの表示されるページのカラム名を日本語化に変化するように書き換え