### PR TITLE
時間の設定(Rails独自のメソッド使用)と日本語化変換のためのコードを記載

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -21,6 +21,8 @@ Bundler.require(*Rails.groups)
 
 module WonderfulPostApp
   class Application < Rails::Application
+    config.time_zone = 'Tokyo'
+    config.active_record.default_timezone = :local
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.0
 
@@ -29,6 +31,10 @@ module WonderfulPostApp
     # -- all .rb files in that directory are automatically loaded after loading
     # the framework and any gems in your application.
 
+    # 以下の記述を追記する(設定必須)
+    # デフォルトのlocaleを日本語(:ja)にする
+    config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.{rb,yml}').to_s]
+    config.i18n.default_locale = :ja
 
     config.generators do |g|
       g.jbuilder false


### PR DESCRIPTION
## 概要
時間を設定
・時間設定のためにconfig.time_zone{デフォルトがUTC(世界時間)}'Tokyo'(JST)と書き換え日本時間に設定(rails cで時間の値も確認)
・データベースにも反映させるためconfig.active_record.default_timezoneを上記の設定時間に合わせるように:localで指定(JST)

日本語化
・前回の日本語化を設定するためにconfig.i18n.default_locale = :ja(:jaは言語指定)を追加
・config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.{rb,yml}').to_s]により設定した翻訳ファイルが全て読み込まれるように追記