### PR TITLE
記事の作成, 編集, 削除をログインユーザーに紐づけを認証機能を提供する gem の devise の機能を使って実装

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,7 @@
 class ApplicationController < ActionController::Base
   add_flash_types :success, :info, :warning, :danger
   before_action :configure_permitted_parameters, if: :devise_controller?
+  before_action :authenticate_user!
   def after_sign_in_path_for(resource)
     articles_path
   end

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -1,5 +1,6 @@
 class ArticlesController < ApplicationController
-  before_action :set_article, only: %i[ show edit update destroy ]
+  skip_before_action :authenticate_user!, only: %i[ index show ]
+  before_action :ensure_user, only: [:edit, :update, :destroy,]
     # GET /articles or /articles.json
 
     def index
@@ -7,7 +8,8 @@ class ArticlesController < ApplicationController
     end
 
     def show
-      @user = @article.user
+      # @user = @article.user
+      @article = Article.find(params[:id])
     end
 
     def new
@@ -57,5 +59,11 @@ class ArticlesController < ApplicationController
 
       def set_article
         @article = Article.find(params[:id])
+      end
+
+      def ensure_user
+        @articles = current_user.articles
+        @article = @articles.find_by(id: params[:id])
+        redirect_to article_path unless @article
       end
 end

--- a/app/views/articles/index.html.erb
+++ b/app/views/articles/index.html.erb
@@ -2,8 +2,6 @@
 
 <h1>記事</h1>
 
-<%= link_to '新しく記事作成', new_article_path, class: "btn btn-info"  %>
-
 <table class="table">
   <thead>
     <tr>
@@ -18,8 +16,6 @@
         <td><%= article.title %></td>
         <td><%= article.content %></td>
         <td><%= link_to '詳細', article, class: "btn btn-success" %></td>
-        <td><%= link_to '編集', edit_article_path(article), class: "btn btn-warning" %></td>
-        <td><%= link_to '削除', article, class: "btn btn-danger", method: :delete, data: { confirm: '削除しますか？' } %></td>
       </tr>
     <% end %>
   </tbody>

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -10,5 +10,7 @@
   </div>
 </div>
 
+<% if current_user&.id == @article.user_id %>
 <%= link_to '編集', edit_article_path(@article), class: "btn btn-warning" %> |
+<% end %>
 <%= link_to '一覧', articles_path, class: "btn btn-secondary" %>


### PR DESCRIPTION
##  概要
・app/controllers/articles_controller.rbに記事がログインしたユーザーかつ作成した人にしか編集できないような設定を
def ensure_userメソッドに記述。(edit,update,destroy)一番最初にこの動作が行われるようにbefore_action :〜を記述
・  また編集ができてログインユーザが作成したものであれば編集ボタンを押せば編集画面に移動するような設定(作成していないユーザーは一覧確認は可)をapp/views/articles/show.html.erbに<% if current_user&.id == @article.user_id %>を記述
・以上のことが全部できたことを確認して記事一覧から作成, 編集, 削除のボタンを削除をapp/views/articles/indexhtml.erbから削除しました




