### PR TITLE
記事とタグのアソシエーションの追加

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -1,3 +1,6 @@
 class Article < ApplicationRecord
   belongs_to :user
+
+  has_many :article_tags, dependent: :destroy
+  has_many :tags, through: :article_tags
 end

--- a/app/models/article_tag.rb
+++ b/app/models/article_tag.rb
@@ -1,0 +1,4 @@
+class ArticleTag < ApplicationRecord
+  belongs_to :article
+  belongs_to :tag
+end

--- a/db/migrate/20221120092525_create_article_tags.rb
+++ b/db/migrate/20221120092525_create_article_tags.rb
@@ -1,0 +1,10 @@
+class CreateArticleTags < ActiveRecord::Migration[6.0]
+  def change
+    create_table :article_tags do |t|
+      t.references :article, foreign_key: true
+      t.references :tag, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_11_04_143138) do
+ActiveRecord::Schema.define(version: 2022_11_20_092525) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "article_tags", force: :cascade do |t|
+    t.bigint "article_id"
+    t.bigint "tag_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["article_id"], name: "index_article_tags_on_article_id"
+    t.index ["tag_id"], name: "index_article_tags_on_tag_id"
+  end
 
   create_table "articles", force: :cascade do |t|
     t.datetime "created_at", precision: 6, null: false
@@ -22,6 +31,12 @@ ActiveRecord::Schema.define(version: 2022_11_04_143138) do
     t.text "content"
     t.bigint "user_id"
     t.index ["user_id"], name: "index_articles_on_user_id"
+  end
+
+  create_table "tags", force: :cascade do |t|
+    t.string "name", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "users", force: :cascade do |t|
@@ -36,5 +51,7 @@ ActiveRecord::Schema.define(version: 2022_11_04_143138) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "article_tags", "articles"
+  add_foreign_key "article_tags", "tags"
   add_foreign_key "articles", "users"
 end


### PR DESCRIPTION
・多対多の関係により中間モデルのarticle_tagモデルを作成(referencese)
・articleモデルとtagモデルにどのように属しているかをお互いに記述
・rails db:migrateを行いアソシエーションされているかの確認を行いました。