### PR TITLE
記事とタグの紐づけての作成と表示

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -56,7 +56,8 @@ class ArticlesController < ApplicationController
     private
       #ストロングパラメータでpermitに渡された値以外を受け取らないようにする
       def article_params
-        params.require(:article).permit(:title,:content)
+        params.require(:article).permit(:title,:content, { :tag_ids=> [] })
+      # tag_idsというパラメータを複数受け取ることのできるように設定するため
       end
 
       def set_article

--- a/app/views/articles/_form.html.erb
+++ b/app/views/articles/_form.html.erb
@@ -1,7 +1,7 @@
 <%= form_with(model: article, local: true) do |form| %>
   <% if article.errors.any? %>
     <div id="error_explanation">
-      <h2><%= pluralize(article.errors.count, "error") %> prohibited this article from being saved:</h2>
+      <h2><%= article.errors.count%> 件の対応が必要です</h2>
 
       <ul>
         <% article.errors.full_messages.each do |message| %>
@@ -10,6 +10,10 @@
       </ul>
     </div>
   <% end %>
+
+  <div class="mb-3">
+    <%= form.collection_check_boxes :tag_ids, Tag.all, :id, :name %>
+  </div>
 
   <div class="mb-3">
     <%= form.label :title, class: "form-label" %>

--- a/app/views/articles/index.html.erb
+++ b/app/views/articles/index.html.erb
@@ -14,7 +14,13 @@
   <tbody>
     <% @articles.each do |article| %>
       <tr>
-        <td><%= article.title %></td>
+         <td>
+          <%= article.title %>
+          <% article.tags.each do |tag| %>
+            <span class="badge rounded-pill bg-primary"><%= tag.name%></span>
+          <% end %>
+        </td>
+
         <td><%= article.content %></td>
         <td><%= link_to '詳細', article, class: "btn btn-success" %></td>
       </tr>

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -3,6 +3,9 @@
 <div class="card">
   <div class="card-header">
     <%= @article.title %>
+      <% @article.tags.each do |tag| %>
+        <span class="badge rounded-pill bg-primary"><%= tag.name%></span>
+      <% end %>
   </div>
 
   <div class="card-body">

--- a/app/views/mypage/show.html.erb
+++ b/app/views/mypage/show.html.erb
@@ -15,7 +15,14 @@
   <tbody>
     <% @articles.each do |article| %>
       <tr>
-        <td><%= article.title %></td>
+        <td>
+          <%= article.title %>
+          <% article.tags.each do |tag| %>
+            <span class="badge rounded-pill bg-primary"><%= tag.name%></span>
+          <% end %>
+        </td>
+
+
         <td><%= article.content %></td>
         <td><%= link_to '詳細', article, class: "btn btn-success" %></td>
         <td><%= link_to '編集', edit_article_path(article), class: "btn btn-success" %></td>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,6 +5,8 @@
 #
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
+tags = %w(成功体験 挑戦 失敗)
+tags.each { |tag| Tag.find_or_create_by!(name: tag) }
 
 3.times do |n|
   n += 1
@@ -17,6 +19,13 @@
     a += 1
     user.articles.find_or_create_by!(title: "No.#{a}: user00#{a}の記事") do |article|
       article.content = "No.#{n}: user00#{n}の記事の本文"
+        article.tag_ids = Tag.all.pluck(:id)
     end
   end
 end
+
+# 3.times do |n|
+#   user.create(
+
+#   )
+# end


### PR DESCRIPTION
・viewsの部分はテンプレートを参照
・記事作成時にパラメータでtag_idsが許可されてないとのことだったのでcontrollers/articles_controllerのprivateのarticle_paramsの所にtag_ids[]を追加
・seedファイルにも記事をつけれるような記述を追加し、サーバーを立てて実際の記事一覧を見てタグがついているかの確認とサーバーのログ確認を行いました