### PR TITLE
N+1の解決

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -4,7 +4,7 @@ class ArticlesController < ApplicationController
     # GET /articles or /articles.json
 
     def index
-      articles = Article.all
+      articles = Article.includes(:tags)
       articles = articles.where("title like?", "%#{params[:title]}%") if params[:title].present?
       @articles = articles.page(params[:page]).per(10)
     end

--- a/app/controllers/mypage_controller.rb
+++ b/app/controllers/mypage_controller.rb
@@ -1,6 +1,6 @@
 class MypageController < ApplicationController
   def show
-    articles = current_user.articles
+    articles = current_user.articles.includes(:tags)
     articles = articles.where("title LIKE ?", "%#{params[:title]}%") if params[:title].present?
     @articles = articles.page params[:page]
   end


### PR DESCRIPTION
・N+1問題で記事一覧とマイページの操作時に記事をloadした際に、tagのSQLがたくさん発行されてしまう問題を解決するためにincludesメソッドをcontrollers/articles_controllerのindexアクションの中にある記事のデータ全部を取得する部分に付け足して関連する(:tags)を記述
・contorollers/mypage_controllersのshowアクションにも同様な記述を行いSQLの発行が減少させられているかの確認まで行いました。(サーバーを立ち上げて確認)